### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/facebook/facebook.py
+++ b/facebook/facebook.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import argparse
 import requests
 import pyquery
@@ -49,6 +51,6 @@ if __name__ == "__main__":
     fb_dtsg, user_id, xs = login(session, args.email, args.password)
     
     if user_id:
-        print '{0}:{1}:{2}'.format(fb_dtsg, user_id, xs)
+        print('{0}:{1}:{2}'.format(fb_dtsg, user_id, xs))
     else:
-        print 'Login Failed'
+        print('Login Failed')


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.