### PR TITLE
Undefined names: import getpass

### DIFF
--- a/baidu2/baidu.py
+++ b/baidu2/baidu.py
@@ -192,7 +192,7 @@ def login(username, password, key):
 
 try:
     input = raw_input
-except:
+except NameError:
     pass
 
 if __name__ == "__main__":

--- a/sina/sina.py
+++ b/sina/sina.py
@@ -1,4 +1,5 @@
 import requests
+import getpass
 import hashlib
 import time
 

--- a/zhihu/zhihu.py
+++ b/zhihu/zhihu.py
@@ -8,6 +8,7 @@ github:https://github.com/CriseLYJ/
 update_time:2019-3-6
 """
 import base64
+import getpass
 import hashlib
 import hmac
 import json


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/CriseLYJ/awesome-python-login-model on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./zhihu/zhihu.py:195:29: F821 undefined name 'getpass'
            self.password = getpass.getpass("password:")
                            ^
./baidu2/baidu.py:194:13: F821 undefined name 'raw_input'
    input = raw_input
            ^
./sina/sina.py:40:11: F821 undefined name 'getpass'
    pwd = getpass.getpass("password:")
          ^
3     F821 undefined name 'raw_input'
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
