### PR TITLE
bilibili.py: Fix SyntaxError: invalid character in identifier

### DIFF
--- a/bilibili/bilibili.py
+++ b/bilibili/bilibili.py
@@ -34,7 +34,7 @@ class BiliBili():
         self.browser = webdriver.Chrome(options=options)
         self.url = 'https://passport.bilibili.com/login'
         self.browser.get(self.url)
-        self.wait = WebDriverWait(self.browser, 5， 0.2)
+        self.wait = WebDriverWait(self.browser, 5, 0.2)
         self.username = username
         self.password = password
 


### PR DESCRIPTION
https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.support.wait

[flake8](http://flake8.pycqa.org) testing of https://github.com/CriseLYJ/awesome-python-login-model on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./bilibili/bilibili.py:37:50: E999 SyntaxError: invalid character in identifier
        self.wait = WebDriverWait(self.browser, 5， 0.2)
                                                 ^
1     E999 SyntaxError: invalid character in identifier
1
```